### PR TITLE
feat: certifications CRUD + compliance page with traffic lights (M3.2)

### DIFF
--- a/__tests__/api/certifications.test.ts
+++ b/__tests__/api/certifications.test.ts
@@ -55,9 +55,11 @@ function profileQb(role: 'admin' | 'member') {
 
 // ─── Shared mock data ─────────────────────────────────────────────────────────
 
+const SUPPLIER_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+
 const mockCert = {
   id: 'cert-1',
-  supplier_id: 'sup-1',
+  supplier_id: SUPPLIER_UUID,
   cert_type: 'ISO',
   issued_date: '2024-01-01',
   expiry_date: addDays(90), // valid
@@ -142,7 +144,7 @@ describe('GET /api/certifications', () => {
     }
     mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
 
-    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=sup-1'))
+    const res = await GET(new Request(`http://localhost/api/certifications?supplier_id=${SUPPLIER_UUID}`))
     expect(res.status).toBe(200)
     const body = await res.json()
 

--- a/__tests__/api/certifications.test.ts
+++ b/__tests__/api/certifications.test.ts
@@ -56,9 +56,10 @@ function profileQb(role: 'admin' | 'member') {
 // ─── Shared mock data ─────────────────────────────────────────────────────────
 
 const SUPPLIER_UUID = 'a1b2c3d4-e5f6-7890-abcd-ef1234567890'
+const CERT_UUID = 'b2c3d4e5-f6a7-8901-bcde-f12345678901'
 
 const mockCert = {
-  id: 'cert-1',
+  id: CERT_UUID,
   supplier_id: SUPPLIER_UUID,
   cert_type: 'ISO',
   issued_date: '2024-01-01',
@@ -151,7 +152,7 @@ describe('GET /api/certifications', () => {
     expect(body.error).toBeNull()
     const certs = body.data
 
-    const valid = certs.find((c: any) => c.id === 'cert-1')
+    const valid = certs.find((c: any) => c.id === CERT_UUID)
     const expired = certs.find((c: any) => c.id === 'cert-expired')
     const expiring = certs.find((c: any) => c.id === 'cert-expiring')
 
@@ -284,36 +285,46 @@ describe('PUT /api/certifications/[id]', () => {
     }
     mockCreateClient.mockReturnValue({ ...authClient(null), from: vi.fn().mockReturnValue(qb) } as any)
 
-    const req = new Request('http://localhost/api/certifications/cert-1', {
+    const req = new Request(`http://localhost/api/certifications/${CERT_UUID}`, {
       method: 'PUT',
       body: JSON.stringify({ expiry_date: addDays(400) }),
       headers: { 'Content-Type': 'application/json' },
     })
-    const res = await PUT(req, { params: { id: 'cert-1' } })
+    const res = await PUT(req, { params: { id: CERT_UUID } })
     expect(res.status).toBe(401)
   })
 
   it('updates certification and returns 200 with computed status', async () => {
     const updatedCert = { ...mockCert, expiry_date: addDays(400) }
 
-    let callCount = 0
+    // fetchQb: select('id').eq().single() — fetch-first existence check
+    const fetchQb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { id: CERT_UUID }, error: null }),
+    }
+    // updateQb: update().eq().select().single()
     const updateQb: any = {
       update: vi.fn().mockReturnThis(),
       eq: vi.fn().mockReturnThis(),
       select: vi.fn().mockReturnThis(),
       single: vi.fn().mockResolvedValue({ data: updatedCert, error: null }),
     }
+    let callCount = 0
     mockCreateClient.mockReturnValue({
       ...authClient('user-1'),
-      from: vi.fn().mockReturnValue(updateQb),
+      from: vi.fn().mockImplementation(() => {
+        callCount++
+        return callCount === 1 ? fetchQb : updateQb
+      }),
     } as any)
 
-    const req = new Request('http://localhost/api/certifications/cert-1', {
+    const req = new Request(`http://localhost/api/certifications/${CERT_UUID}`, {
       method: 'PUT',
       body: JSON.stringify({ expiry_date: addDays(400) }),
       headers: { 'Content-Type': 'application/json' },
     })
-    const res = await PUT(req, { params: { id: 'cert-1' } })
+    const res = await PUT(req, { params: { id: CERT_UUID } })
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.data.status).toBe('valid')
@@ -329,12 +340,12 @@ describe('PUT /api/certifications/[id]', () => {
     }
     mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
 
-    const req = new Request('http://localhost/api/certifications/cert-1', {
+    const req = new Request(`http://localhost/api/certifications/${CERT_UUID}`, {
       method: 'PUT',
       body: JSON.stringify({ cert_type: 'INVALID_TYPE' }),
       headers: { 'Content-Type': 'application/json' },
     })
-    const res = await PUT(req, { params: { id: 'cert-1' } })
+    const res = await PUT(req, { params: { id: CERT_UUID } })
     expect(res.status).toBe(400)
   })
 })
@@ -372,8 +383,8 @@ describe('DELETE /api/certifications/[id] — role checks', () => {
       }),
     } as any)
 
-    const req = new Request('http://localhost/api/certifications/cert-1', { method: 'DELETE' })
-    const res = await DELETE(req, { params: { id: 'cert-1' } })
+    const req = new Request(`http://localhost/api/certifications/${CERT_UUID}`, { method: 'DELETE' })
+    const res = await DELETE(req, { params: { id: CERT_UUID } })
     expect(res.status).toBe(403)
     const body = await res.json()
     expect(body.error.code).toBe('403')
@@ -394,8 +405,8 @@ describe('DELETE /api/certifications/[id] — role checks', () => {
       }),
     } as any)
 
-    const req = new Request('http://localhost/api/certifications/cert-1', { method: 'DELETE' })
-    const res = await DELETE(req, { params: { id: 'cert-1' } })
+    const req = new Request(`http://localhost/api/certifications/${CERT_UUID}`, { method: 'DELETE' })
+    const res = await DELETE(req, { params: { id: CERT_UUID } })
     expect(res.status).toBe(200)
     const body = await res.json()
     expect(body.data).toBeNull()

--- a/__tests__/api/certifications.test.ts
+++ b/__tests__/api/certifications.test.ts
@@ -1,0 +1,451 @@
+/**
+ * CERTIFICATIONS API TESTS — Issues #30, #31 [M3.2]
+ *
+ * TDD RED  🔴 — these tests FAIL until GET/POST/PUT/DELETE routes are implemented.
+ * TDD GREEN 🟢 — tests pass after routes are implemented.
+ *
+ * AC-10-1: expiry_date > 30 days → certification status = 'valid'
+ * AC-10-2: expiry_date within 30 days → certification status = 'expiring'
+ * AC-10-3: expiry_date in the past → certification status = 'expired'
+ * AC-10-4: Supplier with at least one expired cert → flagged red on compliance page
+ * AC-10-5: New certification created → appears on supplier profile and compliance page
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// Mock the server Supabase factory — prevents next/headers from being called
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { GET, POST } from '@/app/api/certifications/route'
+import { PUT, DELETE } from '@/app/api/certifications/[id]/route'
+
+const mockCreateClient = vi.mocked(createClient)
+
+// ─── Date helpers ─────────────────────────────────────────────────────────────
+
+function addDays(days: number): string {
+  const d = new Date()
+  d.setDate(d.getDate() + days)
+  return d.toISOString().split('T')[0]
+}
+
+// ─── Auth helper ──────────────────────────────────────────────────────────────
+
+function authClient(userId: string | null, role: 'admin' | 'member' = 'member') {
+  return {
+    auth: {
+      getUser: vi.fn().mockResolvedValue({
+        data: { user: userId ? { id: userId } : null },
+        error: null,
+      }),
+    },
+  }
+}
+
+function profileQb(role: 'admin' | 'member') {
+  return {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({ data: { role }, error: null }),
+  }
+}
+
+// ─── Shared mock data ─────────────────────────────────────────────────────────
+
+const mockCert = {
+  id: 'cert-1',
+  supplier_id: 'sup-1',
+  cert_type: 'ISO',
+  issued_date: '2024-01-01',
+  expiry_date: addDays(90), // valid
+  document_url: null,
+  created_by: 'user-1',
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+}
+
+const expiredCert = {
+  ...mockCert,
+  id: 'cert-expired',
+  cert_type: 'NDA',
+  expiry_date: addDays(-5), // expired
+}
+
+const expiringCert = {
+  ...mockCert,
+  id: 'cert-expiring',
+  cert_type: 'insurance',
+  expiry_date: addDays(15), // expiring (within 30 days)
+}
+
+const validCreateBody = {
+  supplier_id: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+  cert_type: 'ISO',
+  issued_date: '2024-01-01',
+  expiry_date: addDays(365),
+}
+
+// ─── GET /api/certifications ──────────────────────────────────────────────────
+
+describe('GET /api/certifications', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient(null), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=sup-1'))
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.data).toBeNull()
+    expect(body.error.code).toBe('401')
+  })
+
+  it('returns 400 when supplier_id is missing', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications'))
+    expect(res.status).toBe(400)
+    const body = await res.json()
+    expect(body.error.code).toBe('400')
+  })
+
+  it('returns 400 when supplier_id is not a valid UUID', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=not-a-uuid'))
+    expect(res.status).toBe(400)
+  })
+
+  it('returns certifications with computed status appended (AC-10-1, AC-10-2, AC-10-3)', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [mockCert, expiredCert, expiringCert], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=sup-1'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+
+    expect(body.error).toBeNull()
+    const certs = body.data
+
+    const valid = certs.find((c: any) => c.id === 'cert-1')
+    const expired = certs.find((c: any) => c.id === 'cert-expired')
+    const expiring = certs.find((c: any) => c.id === 'cert-expiring')
+
+    expect(valid.status).toBe('valid')   // AC-10-1
+    expect(expired.status).toBe('expired') // AC-10-3
+    expect(expiring.status).toBe('expiring') // AC-10-2
+  })
+
+  it('returns empty array when supplier has no certifications', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890'))
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toEqual([])
+  })
+})
+
+// ─── POST /api/certifications ─────────────────────────────────────────────────
+
+describe('POST /api/certifications', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    const qb = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient(null), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications', {
+      method: 'POST',
+      body: JSON.stringify(validCreateBody),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(401)
+  })
+
+  it('creates certification and returns 201 with computed status (AC-10-5)', async () => {
+    const newCert = { ...mockCert, id: 'cert-new', expiry_date: addDays(365) }
+    const qb = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: newCert, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications', {
+      method: 'POST',
+      body: JSON.stringify(validCreateBody),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(201)
+    const body = await res.json()
+    expect(body.data.id).toBe('cert-new')
+    expect(body.data.status).toBe('valid') // computed status injected
+    expect(body.error).toBeNull()
+  })
+
+  it('returns 400 when cert_type is invalid', async () => {
+    const qb = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications', {
+      method: 'POST',
+      body: JSON.stringify({ ...validCreateBody, cert_type: 'INVALID' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when supplier_id is not a UUID', async () => {
+    const qb = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications', {
+      method: 'POST',
+      body: JSON.stringify({ ...validCreateBody, supplier_id: 'not-a-uuid' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+
+  it('returns 400 when expiry_date format is invalid', async () => {
+    const qb = {
+      insert: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications', {
+      method: 'POST',
+      body: JSON.stringify({ ...validCreateBody, expiry_date: '01/01/2026' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await POST(req)
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── PUT /api/certifications/[id] ────────────────────────────────────────────
+
+describe('PUT /api/certifications/[id]', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient(null), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications/cert-1', {
+      method: 'PUT',
+      body: JSON.stringify({ expiry_date: addDays(400) }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PUT(req, { params: { id: 'cert-1' } })
+    expect(res.status).toBe(401)
+  })
+
+  it('updates certification and returns 200 with computed status', async () => {
+    const updatedCert = { ...mockCert, expiry_date: addDays(400) }
+
+    let callCount = 0
+    const updateQb: any = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: updatedCert, error: null }),
+    }
+    mockCreateClient.mockReturnValue({
+      ...authClient('user-1'),
+      from: vi.fn().mockReturnValue(updateQb),
+    } as any)
+
+    const req = new Request('http://localhost/api/certifications/cert-1', {
+      method: 'PUT',
+      body: JSON.stringify({ expiry_date: addDays(400) }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PUT(req, { params: { id: 'cert-1' } })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data.status).toBe('valid')
+    expect(body.error).toBeNull()
+  })
+
+  it('returns 400 when update body contains invalid cert_type', async () => {
+    const qb = {
+      update: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      select: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications/cert-1', {
+      method: 'PUT',
+      body: JSON.stringify({ cert_type: 'INVALID_TYPE' }),
+      headers: { 'Content-Type': 'application/json' },
+    })
+    const res = await PUT(req, { params: { id: 'cert-1' } })
+    expect(res.status).toBe(400)
+  })
+})
+
+// ─── DELETE /api/certifications/[id] ─────────────────────────────────────────
+
+describe('DELETE /api/certifications/[id] — role checks', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('returns 401 when not authenticated', async () => {
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient(null), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const req = new Request('http://localhost/api/certifications/cert-1', { method: 'DELETE' })
+    const res = await DELETE(req, { params: { id: 'cert-1' } })
+    expect(res.status).toBe(401)
+  })
+
+  it('returns 403 when Member tries to delete', async () => {
+    let callCount = 0
+    const profileQbMock = profileQb('member')
+    const deleteQb = {
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }
+    mockCreateClient.mockReturnValue({
+      ...authClient('user-1', 'member'),
+      from: vi.fn().mockImplementation(() => {
+        callCount++
+        return callCount === 1 ? profileQbMock : deleteQb
+      }),
+    } as any)
+
+    const req = new Request('http://localhost/api/certifications/cert-1', { method: 'DELETE' })
+    const res = await DELETE(req, { params: { id: 'cert-1' } })
+    expect(res.status).toBe(403)
+    const body = await res.json()
+    expect(body.error.code).toBe('403')
+  })
+
+  it('deletes certification when Admin requests (returns 200)', async () => {
+    let callCount = 0
+    const profileQbMock = profileQb('admin')
+    const deleteQb = {
+      delete: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockResolvedValue({ error: null }),
+    }
+    mockCreateClient.mockReturnValue({
+      ...authClient('user-1', 'admin'),
+      from: vi.fn().mockImplementation(() => {
+        callCount++
+        return callCount === 1 ? profileQbMock : deleteQb
+      }),
+    } as any)
+
+    const req = new Request('http://localhost/api/certifications/cert-1', { method: 'DELETE' })
+    const res = await DELETE(req, { params: { id: 'cert-1' } })
+    expect(res.status).toBe(200)
+    const body = await res.json()
+    expect(body.data).toBeNull()
+    expect(body.error).toBeNull()
+  })
+})
+
+// ─── Certification status computation (AC-10-1, AC-10-2, AC-10-3) ────────────
+
+describe('Certification status computation edge cases', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('status = valid when expiry_date is exactly 31 days from today (AC-10-1)', async () => {
+    const cert = { ...mockCert, expiry_date: addDays(31) }
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [cert], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890'))
+    const body = await res.json()
+    expect(body.data[0].status).toBe('valid')
+  })
+
+  it('status = expiring when expiry_date is exactly 30 days from today (AC-10-2)', async () => {
+    const cert = { ...mockCert, expiry_date: addDays(30) }
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [cert], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890'))
+    const body = await res.json()
+    expect(body.data[0].status).toBe('expiring')
+  })
+
+  it('status = expired when expiry_date is today (AC-10-3)', async () => {
+    const today = new Date().toISOString().split('T')[0]
+    const cert = { ...mockCert, expiry_date: today }
+    const qb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      order: vi.fn().mockResolvedValue({ data: [cert], error: null }),
+    }
+    mockCreateClient.mockReturnValue({ ...authClient('user-1'), from: vi.fn().mockReturnValue(qb) } as any)
+
+    const res = await GET(new Request('http://localhost/api/certifications?supplier_id=a1b2c3d4-e5f6-7890-abcd-ef1234567890'))
+    const body = await res.json()
+    expect(body.data[0].status).toBe('expired')
+  })
+})

--- a/app/(app)/compliance/page.tsx
+++ b/app/(app)/compliance/page.tsx
@@ -1,22 +1,265 @@
-'use client'
+import Link from 'next/link'
+import { ShieldCheck, ShieldAlert, ShieldX, ArrowRight, Plus } from 'lucide-react'
+import { createClient } from '@/lib/supabase/server'
+import { getCertificationStatus } from '@/lib/risk'
+import { cn } from '@/lib/utils'
 
-import { ShieldCheck } from 'lucide-react'
-import { ComingSoonPage } from '@/components/ui/ComingSoonPage'
+type CertStatus = 'valid' | 'expiring' | 'expired'
+type ComplianceLevel = 'green' | 'amber' | 'red' | 'none'
 
-export default function CompliancePage() {
+interface CertRow {
+  id: string
+  cert_type: string
+  expiry_date: string
+  status: CertStatus
+}
+
+interface SupplierRow {
+  id: string
+  name: string
+  category: string | null
+  certifications: CertRow[]
+  complianceLevel: ComplianceLevel
+  validCount: number
+  expiringCount: number
+  expiredCount: number
+}
+
+function getComplianceLevel(certs: CertRow[]): ComplianceLevel {
+  if (certs.length === 0) return 'none'
+  if (certs.some(c => c.status === 'expired')) return 'red'
+  if (certs.some(c => c.status === 'expiring')) return 'amber'
+  return 'green'
+}
+
+const LEVEL_CONFIG: Record<ComplianceLevel, {
+  label: string
+  dot: string
+  badge: string
+  icon: React.ElementType
+}> = {
+  green: {
+    label: 'Compliant',
+    dot: 'bg-emerald-500',
+    badge: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20',
+    icon: ShieldCheck,
+  },
+  amber: {
+    label: 'Expiring',
+    dot: 'bg-amber-500',
+    badge: 'bg-amber-500/15 text-amber-400 border-amber-500/20',
+    icon: ShieldAlert,
+  },
+  red: {
+    label: 'Non-compliant',
+    dot: 'bg-red-500',
+    badge: 'bg-red-500/15 text-red-400 border-red-500/20',
+    icon: ShieldX,
+  },
+  none: {
+    label: 'No certs',
+    dot: 'bg-zinc-500',
+    badge: 'bg-zinc-500/15 text-zinc-400 border-zinc-500/20',
+    icon: ShieldCheck,
+  },
+}
+
+const CERT_TYPE_LABELS: Record<string, string> = {
+  ISO: 'ISO',
+  NDA: 'NDA',
+  insurance: 'Insurance',
+  other: 'Other',
+}
+
+export default async function CompliancePage() {
+  const supabase = createClient()
+
+  const { data: rawSuppliers } = await (supabase
+    .from('suppliers') as any)
+    .select(`
+      id, name, category,
+      certifications(id, cert_type, expiry_date)
+    `)
+    .eq('status', 'active')
+    .order('name') as {
+    data: Array<{
+      id: string
+      name: string
+      category: string | null
+      certifications: Array<{ id: string; cert_type: string; expiry_date: string }>
+    }> | null
+  }
+
+  const today = new Date()
+
+  const suppliers: SupplierRow[] = (rawSuppliers ?? []).map(s => {
+    const certsWithStatus: CertRow[] = (s.certifications ?? []).map(c => ({
+      ...c,
+      status: getCertificationStatus(new Date(c.expiry_date), today),
+    }))
+    const validCount = certsWithStatus.filter(c => c.status === 'valid').length
+    const expiringCount = certsWithStatus.filter(c => c.status === 'expiring').length
+    const expiredCount = certsWithStatus.filter(c => c.status === 'expired').length
+    return {
+      id: s.id,
+      name: s.name,
+      category: s.category,
+      certifications: certsWithStatus,
+      complianceLevel: getComplianceLevel(certsWithStatus),
+      validCount,
+      expiringCount,
+      expiredCount,
+    }
+  })
+
+  // Sort: non-compliant first, then expiring, then compliant, then none
+  const ORDER: Record<ComplianceLevel, number> = { red: 0, amber: 1, green: 2, none: 3 }
+  suppliers.sort((a, b) => ORDER[a.complianceLevel] - ORDER[b.complianceLevel])
+
+  const totalRed = suppliers.filter(s => s.complianceLevel === 'red').length
+  const totalAmber = suppliers.filter(s => s.complianceLevel === 'amber').length
+  const totalGreen = suppliers.filter(s => s.complianceLevel === 'green').length
+  const totalNone = suppliers.filter(s => s.complianceLevel === 'none').length
+
   return (
-    <ComingSoonPage
-      icon={ShieldCheck}
-      iconGradient="from-violet-500 to-purple-600"
-      title="Compliance Center"
-      description="Track supplier certifications, manage compliance documents, and monitor expiry dates across your entire supplier network with traffic-light risk indicators."
-      sprintLabel="Arriving in Sprint 3 · M3.2"
-      features={[
-        'Certification CRUD per supplier (ISO, NDA, Insurance)',
-        'Auto-computed valid / expiring / expired status',
-        'Document upload with signed URL access',
-        'Portfolio-wide compliance summary dashboard',
-      ]}
-    />
+    <div className="space-y-6">
+      {/* Page header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-2xl font-display font-bold tracking-tight text-foreground text-glow">
+            Compliance Center
+          </h2>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Supplier certification status across your portfolio
+          </p>
+        </div>
+      </div>
+
+      {/* Summary bar */}
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        {[
+          { level: 'red' as ComplianceLevel, count: totalRed, label: 'Non-compliant' },
+          { level: 'amber' as ComplianceLevel, count: totalAmber, label: 'Expiring' },
+          { level: 'green' as ComplianceLevel, count: totalGreen, label: 'Compliant' },
+          { level: 'none' as ComplianceLevel, count: totalNone, label: 'No certs' },
+        ].map(({ level, count, label }) => {
+          const cfg = LEVEL_CONFIG[level]
+          return (
+            <div
+              key={level}
+              className="flex items-center gap-3 rounded-xl border border-white/[0.06] bg-white/[0.03] px-4 py-3"
+            >
+              <span className={cn('h-3 w-3 rounded-full flex-shrink-0', cfg.dot)} />
+              <div>
+                <p className="text-xl font-bold text-foreground">{count}</p>
+                <p className="text-xs text-muted-foreground">{label}</p>
+              </div>
+            </div>
+          )
+        })}
+      </div>
+
+      {/* Supplier compliance table */}
+      {suppliers.length === 0 ? (
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] py-16 text-center">
+          <ShieldCheck className="mx-auto h-10 w-10 text-muted-foreground/40" />
+          <p className="mt-3 text-sm text-muted-foreground">No active suppliers found.</p>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-white/[0.06] bg-white/[0.02] overflow-hidden">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-white/[0.06]">
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Supplier</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Category</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+                <th className="px-4 py-3 text-left font-medium text-muted-foreground">Certifications</th>
+                <th className="px-4 py-3 text-right font-medium text-muted-foreground"></th>
+              </tr>
+            </thead>
+            <tbody>
+              {suppliers.map((supplier, i) => {
+                const cfg = LEVEL_CONFIG[supplier.complianceLevel]
+                const Icon = cfg.icon
+                return (
+                  <tr
+                    key={supplier.id}
+                    className={cn(
+                      'border-b border-white/[0.04] transition-colors hover:bg-white/[0.03]',
+                      i === suppliers.length - 1 && 'border-b-0',
+                    )}
+                  >
+                    {/* Supplier name */}
+                    <td className="px-4 py-3.5">
+                      <div className="flex items-center gap-2.5">
+                        <span className={cn('h-2 w-2 rounded-full flex-shrink-0', cfg.dot)} />
+                        <span className="font-medium text-foreground">{supplier.name}</span>
+                      </div>
+                    </td>
+
+                    {/* Category */}
+                    <td className="px-4 py-3.5 text-muted-foreground">
+                      {supplier.category ?? '—'}
+                    </td>
+
+                    {/* Compliance status badge */}
+                    <td className="px-4 py-3.5">
+                      <span
+                        className={cn(
+                          'inline-flex items-center gap-1.5 rounded-full border px-2.5 py-0.5 text-xs font-medium',
+                          cfg.badge,
+                        )}
+                      >
+                        <Icon className="h-3 w-3" />
+                        {cfg.label}
+                      </span>
+                    </td>
+
+                    {/* Cert type chips */}
+                    <td className="px-4 py-3.5">
+                      {supplier.certifications.length === 0 ? (
+                        <span className="text-xs text-muted-foreground/60 italic">None added</span>
+                      ) : (
+                        <div className="flex flex-wrap gap-1.5">
+                          {supplier.certifications.map(cert => {
+                            const statusColour =
+                              cert.status === 'expired' ? 'bg-red-500/15 text-red-400 border-red-500/20' :
+                              cert.status === 'expiring' ? 'bg-amber-500/15 text-amber-400 border-amber-500/20' :
+                              'bg-emerald-500/15 text-emerald-400 border-emerald-500/20'
+                            return (
+                              <span
+                                key={cert.id}
+                                className={cn(
+                                  'rounded-full border px-2 py-0.5 text-[11px] font-medium',
+                                  statusColour,
+                                )}
+                                title={`Expires ${cert.expiry_date}`}
+                              >
+                                {CERT_TYPE_LABELS[cert.cert_type] ?? cert.cert_type}
+                              </span>
+                            )
+                          })}
+                        </div>
+                      )}
+                    </td>
+
+                    {/* Link to supplier profile */}
+                    <td className="px-4 py-3.5 text-right">
+                      <Link
+                        href={`/suppliers/${supplier.id}`}
+                        className="inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-foreground transition-colors"
+                      >
+                        Manage
+                        <ArrowRight className="h-3 w-3" />
+                      </Link>
+                    </td>
+                  </tr>
+                )
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
   )
 }

--- a/app/api/certifications/[id]/route.ts
+++ b/app/api/certifications/[id]/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server'
 import { z } from 'zod'
 import { createClient } from '@/lib/supabase/server'
 import { getCertificationStatus } from '@/lib/risk'
+import { requireAdmin } from '@/lib/auth'
 
 const UpdateCertSchema = z.object({
   cert_type: z.enum(['ISO', 'NDA', 'insurance', 'other']).optional(),
@@ -42,8 +43,8 @@ export async function PUT(
     )
   }
 
-  const { data: cert, error } = await supabase
-    .from('certifications')
+  // Cast needed: certifications table not in generated types yet
+  const { data: cert, error } = await (supabase.from('certifications') as any)
     .update({ ...parsed.data, updated_at: new Date().toISOString() })
     .eq('id', params.id)
     .select()
@@ -65,7 +66,7 @@ export async function PUT(
 }
 
 export async function DELETE(
-  req: Request,
+  _req: Request,
   { params }: { params: { id: string } }
 ) {
   const supabase = createClient()
@@ -78,21 +79,11 @@ export async function DELETE(
     )
   }
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role')
-    .eq('id', user.id)
-    .single()
+  const { error: roleError } = await requireAdmin(supabase, user.id)
+  if (roleError) return roleError
 
-  if (profile?.role !== 'admin') {
-    return NextResponse.json(
-      { data: null, error: { message: 'Forbidden', code: '403' } },
-      { status: 403 }
-    )
-  }
-
-  const { error } = await supabase
-    .from('certifications')
+  // Cast needed: certifications table not in generated types yet
+  const { error } = await (supabase.from('certifications') as any)
     .delete()
     .eq('id', params.id)
 

--- a/app/api/certifications/[id]/route.ts
+++ b/app/api/certifications/[id]/route.ts
@@ -4,6 +4,8 @@ import { createClient } from '@/lib/supabase/server'
 import { getCertificationStatus } from '@/lib/risk'
 import { requireAdmin } from '@/lib/auth'
 
+const UUIDParam = z.string().uuid()
+
 const UpdateCertSchema = z.object({
   cert_type: z.enum(['ISO', 'NDA', 'insurance', 'other']).optional(),
   issued_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
@@ -25,6 +27,14 @@ export async function PUT(
     )
   }
 
+  // Validate path param is a UUID (A03 defense-in-depth)
+  if (!UUIDParam.safeParse(params.id).success) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Invalid id', code: '400' } },
+      { status: 400 }
+    )
+  }
+
   let body: unknown
   try {
     body = await req.json()
@@ -43,7 +53,19 @@ export async function PUT(
     )
   }
 
-  // Cast needed: certifications table not in generated types yet
+  // Fetch-first: confirm cert exists before updating (A01 — prevents existence leakage)
+  const { data: existing, error: fetchError } = await (supabase.from('certifications') as any)
+    .select('id')
+    .eq('id', params.id)
+    .single()
+
+  if (fetchError || !existing) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Certification not found', code: '404' } },
+      { status: 404 }
+    )
+  }
+
   const { data: cert, error } = await (supabase.from('certifications') as any)
     .update({ ...parsed.data, updated_at: new Date().toISOString() })
     .eq('id', params.id)
@@ -52,7 +74,7 @@ export async function PUT(
 
   if (error) {
     return NextResponse.json(
-      { data: null, error: { message: error.message, code: '500' } },
+      { data: null, error: { message: 'Internal server error', code: '500' } },
       { status: 500 }
     )
   }
@@ -79,17 +101,24 @@ export async function DELETE(
     )
   }
 
+  // Validate path param is a UUID (A03 defense-in-depth)
+  if (!UUIDParam.safeParse(params.id).success) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Invalid id', code: '400' } },
+      { status: 400 }
+    )
+  }
+
   const { error: roleError } = await requireAdmin(supabase, user.id)
   if (roleError) return roleError
 
-  // Cast needed: certifications table not in generated types yet
   const { error } = await (supabase.from('certifications') as any)
     .delete()
     .eq('id', params.id)
 
   if (error) {
     return NextResponse.json(
-      { data: null, error: { message: error.message, code: '500' } },
+      { data: null, error: { message: 'Internal server error', code: '500' } },
       { status: 500 }
     )
   }

--- a/app/api/certifications/[id]/route.ts
+++ b/app/api/certifications/[id]/route.ts
@@ -1,11 +1,107 @@
-// TODO: Implement PUT and DELETE for single certification (M3.2)
-// DELETE is Admin-only
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { getCertificationStatus } from '@/lib/risk'
 
-export async function PUT(_req: Request, { params }: { params: { id: string } }) {
-  return NextResponse.json({ data: null, error: { message: 'Not implemented', code: '501' } }, { status: 501 })
+const UpdateCertSchema = z.object({
+  cert_type: z.enum(['ISO', 'NDA', 'insurance', 'other']).optional(),
+  issued_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  expiry_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  document_url: z.string().url().optional(),
+}).strict()
+
+export async function PUT(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createClient()
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Unauthorized', code: '401' } },
+      { status: 401 }
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { data: null, error: { message: 'Invalid JSON body', code: '400' } },
+      { status: 400 }
+    )
+  }
+
+  const parsed = UpdateCertSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { data: null, error: { message: parsed.error.errors[0]?.message ?? 'Validation error', code: '400' } },
+      { status: 400 }
+    )
+  }
+
+  const { data: cert, error } = await supabase
+    .from('certifications')
+    .update({ ...parsed.data, updated_at: new Date().toISOString() })
+    .eq('id', params.id)
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { data: null, error: { message: error.message, code: '500' } },
+      { status: 500 }
+    )
+  }
+
+  const certWithStatus = {
+    ...(cert as any),
+    status: getCertificationStatus(new Date((cert as any).expiry_date)),
+  }
+
+  return NextResponse.json({ data: certWithStatus, error: null })
 }
 
-export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
-  return NextResponse.json({ data: null, error: { message: 'Not implemented', code: '501' } }, { status: 501 })
+export async function DELETE(
+  req: Request,
+  { params }: { params: { id: string } }
+) {
+  const supabase = createClient()
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Unauthorized', code: '401' } },
+      { status: 401 }
+    )
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single()
+
+  if (profile?.role !== 'admin') {
+    return NextResponse.json(
+      { data: null, error: { message: 'Forbidden', code: '403' } },
+      { status: 403 }
+    )
+  }
+
+  const { error } = await supabase
+    .from('certifications')
+    .delete()
+    .eq('id', params.id)
+
+  if (error) {
+    return NextResponse.json(
+      { data: null, error: { message: error.message, code: '500' } },
+      { status: 500 }
+    )
+  }
+
+  return NextResponse.json({ data: null, error: null })
 }

--- a/app/api/certifications/route.ts
+++ b/app/api/certifications/route.ts
@@ -46,7 +46,7 @@ export async function GET(req: Request) {
 
   if (error) {
     return NextResponse.json(
-      { data: null, error: { message: error.message, code: '500' } },
+      { data: null, error: { message: 'Internal server error', code: '500' } },
       { status: 500 }
     )
   }
@@ -97,7 +97,7 @@ export async function POST(req: Request) {
 
   if (error) {
     return NextResponse.json(
-      { data: null, error: { message: error.message, code: '500' } },
+      { data: null, error: { message: 'Internal server error', code: '500' } },
       { status: 500 }
     )
   }

--- a/app/api/certifications/route.ts
+++ b/app/api/certifications/route.ts
@@ -1,10 +1,111 @@
-// TODO: Implement GET (by supplier_id) and POST for certifications (M3.2)
 import { NextResponse } from 'next/server'
+import { z } from 'zod'
+import { createClient } from '@/lib/supabase/server'
+import { getCertificationStatus } from '@/lib/risk'
 
-export async function GET() {
-  return NextResponse.json({ data: [], error: null })
+const GetQuerySchema = z.object({
+  supplier_id: z.string().uuid(),
+})
+
+const CreateCertSchema = z.object({
+  supplier_id: z.string().uuid(),
+  cert_type: z.enum(['ISO', 'NDA', 'insurance', 'other']),
+  issued_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/).optional(),
+  expiry_date: z.string().regex(/^\d{4}-\d{2}-\d{2}$/),
+  document_url: z.string().url().optional(),
+})
+
+export async function GET(req: Request) {
+  const supabase = createClient()
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Unauthorized', code: '401' } },
+      { status: 401 }
+    )
+  }
+
+  const { searchParams } = new URL(req.url)
+  const parsed = GetQuerySchema.safeParse({ supplier_id: searchParams.get('supplier_id') ?? undefined })
+
+  if (!parsed.success) {
+    return NextResponse.json(
+      { data: null, error: { message: 'supplier_id query param is required and must be a UUID', code: '400' } },
+      { status: 400 }
+    )
+  }
+
+  const { supplier_id } = parsed.data
+
+  const { data: certs, error } = await supabase
+    .from('certifications')
+    .select('*')
+    .eq('supplier_id', supplier_id)
+    .order('expiry_date', { ascending: true })
+
+  if (error) {
+    return NextResponse.json(
+      { data: null, error: { message: error.message, code: '500' } },
+      { status: 500 }
+    )
+  }
+
+  const today = new Date()
+  const certsWithStatus = (certs as any[]).map(cert => ({
+    ...cert,
+    status: getCertificationStatus(new Date(cert.expiry_date), today),
+  }))
+
+  return NextResponse.json({ data: certsWithStatus, error: null })
 }
 
-export async function POST() {
-  return NextResponse.json({ data: null, error: { message: 'Not implemented', code: '501' } }, { status: 501 })
+export async function POST(req: Request) {
+  const supabase = createClient()
+
+  const { data: { user } } = await supabase.auth.getUser()
+  if (!user) {
+    return NextResponse.json(
+      { data: null, error: { message: 'Unauthorized', code: '401' } },
+      { status: 401 }
+    )
+  }
+
+  let body: unknown
+  try {
+    body = await req.json()
+  } catch {
+    return NextResponse.json(
+      { data: null, error: { message: 'Invalid JSON body', code: '400' } },
+      { status: 400 }
+    )
+  }
+
+  const parsed = CreateCertSchema.safeParse(body)
+  if (!parsed.success) {
+    return NextResponse.json(
+      { data: null, error: { message: parsed.error.errors[0]?.message ?? 'Validation error', code: '400' } },
+      { status: 400 }
+    )
+  }
+
+  const { data: cert, error } = await supabase
+    .from('certifications')
+    .insert({ ...parsed.data, created_by: user.id })
+    .select()
+    .single()
+
+  if (error) {
+    return NextResponse.json(
+      { data: null, error: { message: error.message, code: '500' } },
+      { status: 500 }
+    )
+  }
+
+  const certWithStatus = {
+    ...(cert as any),
+    status: getCertificationStatus(new Date((cert as any).expiry_date)),
+  }
+
+  return NextResponse.json({ data: certWithStatus, error: null }, { status: 201 })
 }

--- a/app/api/certifications/route.ts
+++ b/app/api/certifications/route.ts
@@ -38,8 +38,8 @@ export async function GET(req: Request) {
 
   const { supplier_id } = parsed.data
 
-  const { data: certs, error } = await supabase
-    .from('certifications')
+  // Cast needed: certifications table type not in generated types yet
+  const { data: certs, error } = await (supabase.from('certifications') as any)
     .select('*')
     .eq('supplier_id', supplier_id)
     .order('expiry_date', { ascending: true })
@@ -89,8 +89,8 @@ export async function POST(req: Request) {
     )
   }
 
-  const { data: cert, error } = await supabase
-    .from('certifications')
+  // Cast needed: certifications table not in generated types yet
+  const { data: cert, error } = await (supabase.from('certifications') as any)
     .insert({ ...parsed.data, created_by: user.id })
     .select()
     .single()

--- a/e2e/compliance.spec.ts
+++ b/e2e/compliance.spec.ts
@@ -1,0 +1,251 @@
+/**
+ * COMPLIANCE PAGE — Playwright E2E
+ * Issues #30, #31 [M3.2]
+ *
+ * Acceptance Criteria covered:
+ *   AC-10-1: expiry_date > 30 days → certification status = 'valid' → chip rendered
+ *   AC-10-2: expiry_date within 30 days → certification status = 'expiring' → amber chip
+ *   AC-10-3: expiry_date in the past → certification status = 'expired' → red chip
+ *   AC-10-4: Supplier with at least one expired cert → 'Non-compliant' badge
+ *   AC-10-5: New certification created → appears on supplier profile and compliance page
+ *
+ * Also covers:
+ *   - Unauthenticated redirect (middleware, no creds needed)
+ *   - Page renders: heading (h2 "Compliance Center"), summary bar, table, sidebar nav, dark theme
+ *   - Sort order: red → amber → green → none
+ *   - Empty state when no active suppliers exist
+ */
+
+import { test, expect } from '@playwright/test'
+import fs from 'fs'
+
+const hasAuth = (() => {
+  try {
+    const state = JSON.parse(fs.readFileSync('e2e/.auth/user.json', 'utf8'))
+    return Array.isArray(state.cookies) && state.cookies.length > 0
+  } catch {
+    return false
+  }
+})()
+
+// ─── Unauthenticated redirect ─────────────────────────────────────────────────
+
+test.describe('Compliance — unauthenticated redirect', () => {
+  test.use({ storageState: { cookies: [], origins: [] } })
+
+  test('GET /compliance → /login', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page).toHaveURL(/\/login/)
+  })
+})
+
+// ─── Authenticated renders ────────────────────────────────────────────────────
+
+test.describe('Compliance — authenticated renders', () => {
+  test.skip(!hasAuth, 'E2E_EMAIL not configured — add to .env.test to enable')
+
+  test('renders "Compliance Center" heading (level 2)', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page.getByRole('heading', { name: /compliance center/i, level: 2 })).toBeVisible()
+  })
+
+  test('dark theme applied', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page.locator('html')).toHaveClass(/\bdark\b/)
+  })
+
+  test('sidebar navigation is visible with all 6 links', async ({ page }) => {
+    await page.goto('/compliance')
+    const sidebar = page.locator('aside')
+    await expect(sidebar).toBeVisible()
+    for (const label of ['Dashboard', 'Contracts', 'Suppliers', 'Compliance', 'Spend', 'Notifications']) {
+      await expect(sidebar.getByRole('link', { name: label, exact: true })).toBeVisible()
+    }
+  })
+
+  test('renders summary bar with four compliance labels', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page.getByText('Non-compliant').first()).toBeVisible()
+    await expect(page.getByText('Expiring').first()).toBeVisible()
+    await expect(page.getByText('Compliant').first()).toBeVisible()
+    await expect(page.getByText('No certs').first()).toBeVisible()
+  })
+
+  test('renders supplier table with column headers', async ({ page }) => {
+    await page.goto('/compliance')
+    // Table is rendered if there are any active suppliers; else empty state
+    // Both paths should render without error
+    const hasTable = await page.locator('table').isVisible().catch(() => false)
+    const hasEmpty = await page.getByText(/no active suppliers found/i).isVisible().catch(() => false)
+    expect(hasTable || hasEmpty).toBe(true)
+  })
+
+  test('no error boundary rendered', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page.getByText(/something went wrong/i)).not.toBeVisible()
+  })
+})
+
+// ─── AC-10: Certification status — seed supplier + certs ─────────────────────
+// Seeds: 1 supplier with 3 certs
+//   Cert A — valid:    expiry +90 days  (AC-10-1)
+//   Cert B — expiring: expiry +15 days  (AC-10-2)
+//   Cert C — expired:  expiry -10 days  (AC-10-3)
+// Expected: supplier has 'Non-compliant' badge (AC-10-4), all cert chips visible (AC-10-5)
+
+test.describe('AC-10: Certification status on compliance page', () => {
+  test.skip(!hasAuth, 'E2E_EMAIL not configured — add to .env.test to enable')
+
+  let supplierId: string
+  let certValidId: string
+  let certExpiringId: string
+  let certExpiredId: string
+
+  const isoDate = (offsetDays: number) => {
+    const d = new Date()
+    d.setDate(d.getDate() + offsetDays)
+    return d.toISOString().split('T')[0]
+  }
+
+  test.beforeAll(async ({ request }) => {
+    // Create supplier
+    const sRes = await request.post('/api/suppliers', {
+      data: { name: 'E2E Compliance Supplier', category: 'E2E Testing' },
+    })
+    supplierId = (await sRes.json()).data?.id
+
+    // Cert A — valid (expiry +90 days)
+    const cARes = await request.post('/api/certifications', {
+      data: { supplier_id: supplierId, cert_type: 'ISO', expiry_date: isoDate(90) },
+    })
+    certValidId = (await cARes.json()).data?.id
+
+    // Cert B — expiring (expiry +15 days)
+    const cBRes = await request.post('/api/certifications', {
+      data: { supplier_id: supplierId, cert_type: 'NDA', expiry_date: isoDate(15) },
+    })
+    certExpiringId = (await cBRes.json()).data?.id
+
+    // Cert C — expired (expiry -10 days)
+    const cCRes = await request.post('/api/certifications', {
+      data: { supplier_id: supplierId, cert_type: 'insurance', expiry_date: isoDate(-10) },
+    })
+    certExpiredId = (await cCRes.json()).data?.id
+  })
+
+  test.afterAll(async ({ request }) => {
+    if (certValidId)    await request.delete(`/api/certifications/${certValidId}`)
+    if (certExpiringId) await request.delete(`/api/certifications/${certExpiringId}`)
+    if (certExpiredId)  await request.delete(`/api/certifications/${certExpiredId}`)
+    if (supplierId)     await request.delete(`/api/suppliers/${supplierId}`)
+  })
+
+  test('supplier row is visible on compliance page (AC-10-5)', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page.getByText('E2E Compliance Supplier')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('supplier with expired cert shows Non-compliant badge (AC-10-4)', async ({ page }) => {
+    await page.goto('/compliance')
+    const row = page.locator('tr').filter({ hasText: 'E2E Compliance Supplier' })
+    await expect(row).toBeVisible({ timeout: 10000 })
+    await expect(row.getByText('Non-compliant')).toBeVisible()
+  })
+
+  test('ISO cert chip visible in supplier row (AC-10-5)', async ({ page }) => {
+    await page.goto('/compliance')
+    const row = page.locator('tr').filter({ hasText: 'E2E Compliance Supplier' })
+    await expect(row.getByText('ISO')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('NDA cert chip visible in supplier row (AC-10-5)', async ({ page }) => {
+    await page.goto('/compliance')
+    const row = page.locator('tr').filter({ hasText: 'E2E Compliance Supplier' })
+    await expect(row.getByText('NDA')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('Insurance cert chip visible in supplier row (AC-10-5)', async ({ page }) => {
+    await page.goto('/compliance')
+    const row = page.locator('tr').filter({ hasText: 'E2E Compliance Supplier' })
+    await expect(row.getByText('Insurance')).toBeVisible({ timeout: 10000 })
+  })
+
+  test('Manage link navigates to supplier profile', async ({ page }) => {
+    await page.goto('/compliance')
+    const row = page.locator('tr').filter({ hasText: 'E2E Compliance Supplier' })
+    await expect(row).toBeVisible({ timeout: 10000 })
+    await row.getByRole('link', { name: /manage/i }).click()
+    await expect(page).toHaveURL(new RegExp(`/suppliers/${supplierId}`))
+  })
+})
+
+// ─── Sort order: red → amber → green → none ──────────────────────────────────
+
+test.describe('Compliance — sort order (red before green)', () => {
+  test.skip(!hasAuth, 'E2E_EMAIL not configured — add to .env.test to enable')
+
+  let redSupplierId: string
+  let greenSupplierId: string
+  let redCertId: string
+  let greenCertId: string
+
+  const isoDate = (offsetDays: number) => {
+    const d = new Date()
+    d.setDate(d.getDate() + offsetDays)
+    return d.toISOString().split('T')[0]
+  }
+
+  test.beforeAll(async ({ request }) => {
+    // Red supplier — expired cert
+    const rsRes = await request.post('/api/suppliers', {
+      data: { name: 'E2E Red Compliance Supplier', category: 'E2E Testing' },
+    })
+    redSupplierId = (await rsRes.json()).data?.id
+    const rcRes = await request.post('/api/certifications', {
+      data: { supplier_id: redSupplierId, cert_type: 'ISO', expiry_date: isoDate(-5) },
+    })
+    redCertId = (await rcRes.json()).data?.id
+
+    // Green supplier — valid cert
+    const gsRes = await request.post('/api/suppliers', {
+      data: { name: 'E2E Green Compliance Supplier', category: 'E2E Testing' },
+    })
+    greenSupplierId = (await gsRes.json()).data?.id
+    const gcRes = await request.post('/api/certifications', {
+      data: { supplier_id: greenSupplierId, cert_type: 'ISO', expiry_date: isoDate(90) },
+    })
+    greenCertId = (await gcRes.json()).data?.id
+  })
+
+  test.afterAll(async ({ request }) => {
+    if (redCertId)   await request.delete(`/api/certifications/${redCertId}`)
+    if (greenCertId) await request.delete(`/api/certifications/${greenCertId}`)
+    if (redSupplierId)   await request.delete(`/api/suppliers/${redSupplierId}`)
+    if (greenSupplierId) await request.delete(`/api/suppliers/${greenSupplierId}`)
+  })
+
+  test('non-compliant supplier appears before compliant supplier in table', async ({ page }) => {
+    await page.goto('/compliance')
+    await expect(page.getByText('E2E Red Compliance Supplier')).toBeVisible({ timeout: 10000 })
+    await expect(page.getByText('E2E Green Compliance Supplier')).toBeVisible()
+
+    const rows = page.locator('tbody tr')
+    const allText = await rows.allTextContents()
+
+    const redIdx = allText.findIndex(t => t.includes('E2E Red Compliance Supplier'))
+    const greenIdx = allText.findIndex(t => t.includes('E2E Green Compliance Supplier'))
+
+    expect(redIdx).toBeGreaterThanOrEqual(0)
+    expect(greenIdx).toBeGreaterThanOrEqual(0)
+    expect(redIdx).toBeLessThan(greenIdx)
+  })
+})
+
+// ─── Empty state ──────────────────────────────────────────────────────────────
+
+test.describe('Compliance — empty state', () => {
+  test.fixme('shows "No active suppliers found" when no active suppliers exist', async () => {
+    // Requires an isolated environment with no active suppliers.
+    // Covered indirectly: table column headers are the primary renders test above.
+  })
+})

--- a/lib/risk.ts
+++ b/lib/risk.ts
@@ -31,3 +31,17 @@ export function diffInDays(dateA: Date, dateB: Date): number {
   const msPerDay = 1000 * 60 * 60 * 24
   return Math.floor((dateA.getTime() - dateB.getTime()) / msPerDay)
 }
+
+export type CertificationStatus = 'valid' | 'expiring' | 'expired'
+
+export function getCertificationStatus(
+  expiryDate: Date,
+  today: Date = new Date()
+): CertificationStatus {
+  // Truncate both to midnight (dates stored as DATE type, parsed as midnight UTC)
+  const todayMidnight = new Date(today.toISOString().split('T')[0] + 'T00:00:00Z')
+  const expiryMidnight = new Date(expiryDate.toISOString().split('T')[0] + 'T00:00:00Z')
+  if (expiryMidnight <= todayMidnight) return 'expired'
+  if (diffInDays(expiryMidnight, todayMidnight) <= 30) return 'expiring'
+  return 'valid'
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -76,6 +76,17 @@ export default defineConfig({
       },
       dependencies: ['setup'],
     },
+
+    // Compliance page tests (authenticated + unauthenticated redirect)
+    {
+      name: 'compliance-pages',
+      testMatch: /compliance\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        storageState: 'e2e/.auth/user.json',
+      },
+      dependencies: ['setup'],
+    },
   ],
 
   // Automatically start the Next.js dev server


### PR DESCRIPTION
## Summary

- Implements certifications CRUD API (issue #30) — `GET /api/certifications?supplier_id=`, `POST /api/certifications`, `PUT /api/certifications/[id]`, `DELETE /api/certifications/[id]` (Admin-only delete)
- Adds `getCertificationStatus()` to `lib/risk.ts` with midnight UTC truncation to correctly handle the 30-day boundary (issue #30)
- Builds compliance page (issue #31) — server component with Supabase nested select, supplier rows sorted red → amber → green → none, cert-type chips with status colours, summary count bar
- Security hardened: UUID path param validation (A03), fetch-first existence check in PUT (A01), no `error.message` leakage in 500s (A05)
- All 174 tests pass (19 new certification tests covering all ACs + edge cases)

## TDD commit sequence

| Commit | Phase | Description |
|--------|-------|-------------|
| `61fb1e6` | 🔴 RED | `test: add failing tests for certifications CRUD (AC-10-1 through AC-10-5)` |
| `5951395` | 🟢 GREEN | `feat: implement certifications CRUD + getCertificationStatus` |
| `0d76405` | ✅ FEAT | `feat: build compliance page` |
| `30d05d8` | 🔒 FIX | `fix: harden certifications routes — UUID validation, fetch-first A01, no error leakage` |

## AC coverage

- **AC-10-1** ✅ `expiry_date > 30 days` → `status = 'valid'`
- **AC-10-2** ✅ `expiry_date within 30 days` → `status = 'expiring'`
- **AC-10-3** ✅ `expiry_date in the past` → `status = 'expired'`
- **AC-10-4** ✅ Supplier with expired cert flagged red on compliance page
- **AC-10-5** ✅ New cert created via POST appears in GET response

## Security review

Passed `security-reviewer` agent — no OWASP findings.

## Test plan

- [x] `npm test -- __tests__/api/certifications.test.ts` → 19/19 pass
- [x] `npm test` → 174/174 pass
- [x] Navigate to `/compliance` in dev — supplier rows visible with cert chips _(verified via Playwright MCP browser: QA Test Supplier Ltd shows ISO chip + Compliant badge)_
- [x] `DELETE /api/certifications/{id}` as Member → 403 _(verified by unit test "returns 403 when Member tries to delete")_
- [x] `PUT /api/certifications/not-a-uuid` → 400 _(verified via browser fetch: status 400, code "400")_
- [x] `PUT /api/certifications/{nonexistent-uuid}` → 404 _(verified via browser fetch: status 404, code "404")_

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #30
Closes #31