### PR TITLE
feat: send Resend email alerts in cron notifications route

### DIFF
--- a/__tests__/api/cron.test.ts
+++ b/__tests__/api/cron.test.ts
@@ -74,8 +74,11 @@ function mockSupabaseClient(opts: {
 }) {
   const { contracts = [], profileEmail = OWNER_EMAIL, insertError = null } = opts
 
-  // contracts: awaitable select chain
-  const contractsQb: any = { select: vi.fn().mockReturnThis() }
+  // contracts: awaitable select → limit chain
+  const contractsQb: any = {
+    select: vi.fn().mockReturnThis(),
+    limit: vi.fn().mockReturnThis(),
+  }
   contractsQb.then = (resolve: (v: unknown) => unknown) =>
     Promise.resolve({ data: contracts, error: null }).then(resolve)
 
@@ -232,7 +235,7 @@ describe('GET /api/cron/notifications — email sending (AC-08-1, AC-08-2, AC-08
     const notificationsQb = {
       insert: vi.fn().mockResolvedValue({ data: null, error: null }),
     }
-    const contractsQb: any = { select: vi.fn().mockReturnThis() }
+    const contractsQb: any = { select: vi.fn().mockReturnThis(), limit: vi.fn().mockReturnThis() }
     contractsQb.then = (resolve: (v: unknown) => unknown) =>
       Promise.resolve({ data: [mockContract, contract2], error: null }).then(resolve)
 

--- a/__tests__/api/cron.test.ts
+++ b/__tests__/api/cron.test.ts
@@ -13,7 +13,11 @@ import { describe, it, expect, vi, beforeEach } from 'vitest'
 
 // ─── Mocks (hoisted before imports by Vitest) ─────────────────────────────────
 
-const mockSend = vi.fn().mockResolvedValue({ data: { id: 'email-id' }, error: null })
+// vi.hoisted() runs before vi.mock factories AND before imports — safe to close over
+const { mockSend } = vi.hoisted(() => {
+  const mockSend = vi.fn().mockResolvedValue({ data: { id: 'email-id' }, error: null })
+  return { mockSend }
+})
 
 vi.mock('resend', () => ({
   Resend: vi.fn().mockImplementation(() => ({

--- a/__tests__/api/cron.test.ts
+++ b/__tests__/api/cron.test.ts
@@ -1,0 +1,257 @@
+/**
+ * CRON NOTIFICATIONS ROUTE TESTS — Issue #27 [M3.0]
+ *
+ * TDD RED  🔴 — AC-08-1 through AC-08-3 FAIL until Resend email sending is added to the cron route.
+ * TDD GREEN 🟢 — tests pass after route is augmented with email sending.
+ *
+ * AC-08-1: Contract at threshold → email sent to contract owner's email address
+ * AC-08-2: Insert fails (23505 unique violation) → email NOT sent (deduplication enforced)
+ * AC-08-3: Email uses freshly fetched profile email on each cron run (not cached)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+
+// ─── Mocks (hoisted before imports by Vitest) ─────────────────────────────────
+
+const mockSend = vi.fn().mockResolvedValue({ data: { id: 'email-id' }, error: null })
+
+vi.mock('resend', () => ({
+  Resend: vi.fn().mockImplementation(() => ({
+    emails: { send: mockSend },
+  })),
+}))
+
+vi.mock('@/lib/supabase/server', () => ({
+  createClient: vi.fn(),
+}))
+
+// Mock shouldSendAlert so tests control exactly when alerts fire
+// (threshold logic is tested in __tests__/lib/alerts.test.ts)
+vi.mock('@/lib/alerts', () => ({
+  shouldSendAlert: vi.fn(),
+  ALERT_THRESHOLDS: [60, 30, 7] as const,
+}))
+
+import { createClient } from '@/lib/supabase/server'
+import { shouldSendAlert } from '@/lib/alerts'
+import { GET } from '@/app/api/cron/notifications/route'
+
+const mockCreateClient = vi.mocked(createClient)
+const mockShouldSendAlert = vi.mocked(shouldSendAlert)
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const CONTRACT_UUID = 'c1d2e3f4-a5b6-7890-cdef-123456789012'
+const USER_UUID = 'u1v2w3x4-y5z6-7890-abcd-ef1234567890'
+const OWNER_EMAIL = 'owner@example.com'
+const CRON_SECRET = 'test-cron-secret'
+
+const mockContract = {
+  id: CONTRACT_UUID,
+  name: 'Acme Service Agreement',
+  renewal_date: '2026-05-09',
+  notice_period_days: 14,
+  created_by: USER_UUID,
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeCronRequest(secret = CRON_SECRET) {
+  return new Request('http://localhost/api/cron/notifications', {
+    headers: { authorization: `Bearer ${secret}` },
+  })
+}
+
+/** Builds a mock Supabase client dispatching from() by table name. */
+function mockSupabaseClient(opts: {
+  contracts?: unknown[]
+  profileEmail?: string | null
+  insertError?: { code: string; message: string } | null
+}) {
+  const { contracts = [], profileEmail = OWNER_EMAIL, insertError = null } = opts
+
+  // contracts: awaitable select chain
+  const contractsQb: any = { select: vi.fn().mockReturnThis() }
+  contractsQb.then = (resolve: (v: unknown) => unknown) =>
+    Promise.resolve({ data: contracts, error: null }).then(resolve)
+
+  // profiles: select → eq → single
+  const profilesQb = {
+    select: vi.fn().mockReturnThis(),
+    eq: vi.fn().mockReturnThis(),
+    single: vi.fn().mockResolvedValue({
+      data: profileEmail ? { email: profileEmail } : null,
+      error: null,
+    }),
+  }
+
+  // notifications: insert
+  const notificationsQb = {
+    insert: vi.fn().mockResolvedValue({ data: null, error: insertError }),
+  }
+
+  return {
+    from: vi.fn().mockImplementation((table: string) => {
+      if (table === 'contracts') return contractsQb
+      if (table === 'profiles') return profilesQb
+      if (table === 'notifications') return notificationsQb
+      return {}
+    }),
+  }
+}
+
+// ─── Auth guard tests ─────────────────────────────────────────────────────────
+
+describe('GET /api/cron/notifications — auth guard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = CRON_SECRET
+  })
+
+  it('returns 401 when authorization header is absent', async () => {
+    const res = await GET(new Request('http://localhost/api/cron/notifications'))
+    expect(res.status).toBe(401)
+    const body = await res.json()
+    expect(body.error.code).toBe('401')
+  })
+
+  it('returns 401 when CRON_SECRET does not match', async () => {
+    const res = await GET(
+      new Request('http://localhost/api/cron/notifications', {
+        headers: { authorization: 'Bearer wrong-secret' },
+      })
+    )
+    expect(res.status).toBe(401)
+  })
+})
+
+// ─── Email alert tests (AC-08-x) ─────────────────────────────────────────────
+
+describe('GET /api/cron/notifications — email sending (AC-08-1, AC-08-2, AC-08-3)', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    process.env.CRON_SECRET = CRON_SECRET
+    // Default: only the 30-day threshold fires (keeps tests focused on one email)
+    mockShouldSendAlert.mockImplementation(
+      (_date: Date, threshold: number) => threshold === 30
+    )
+  })
+
+  it('AC-08-1: sends email to contract owner when insert succeeds', async () => {
+    mockCreateClient.mockReturnValue(
+      mockSupabaseClient({ contracts: [mockContract], profileEmail: OWNER_EMAIL }) as any
+    )
+
+    const res = await GET(makeCronRequest())
+    expect(res.status).toBe(200)
+
+    // Exactly one email sent
+    expect(mockSend).toHaveBeenCalledOnce()
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        to: OWNER_EMAIL,
+        subject: expect.stringContaining('Acme Service Agreement'),
+      })
+    )
+  })
+
+  it('AC-08-2: does NOT send email when insert fails with unique violation (23505)', async () => {
+    mockCreateClient.mockReturnValue(
+      mockSupabaseClient({
+        contracts: [mockContract],
+        profileEmail: OWNER_EMAIL,
+        insertError: { code: '23505', message: 'unique_violation' },
+      }) as any
+    )
+
+    const res = await GET(makeCronRequest())
+    expect(res.status).toBe(200)
+
+    // No email — duplicate notification blocked at DB level
+    expect(mockSend).not.toHaveBeenCalled()
+
+    // Inserted count reflects no new rows
+    const body = await res.json()
+    expect(body.data.inserted).toBe(0)
+  })
+
+  it('AC-08-3: fetches profile email fresh each cron run (not hardcoded or cached)', async () => {
+    const UPDATED_EMAIL = 'new-address@example.com'
+    const client = mockSupabaseClient({
+      contracts: [mockContract],
+      profileEmail: UPDATED_EMAIL,
+    }) as any
+    mockCreateClient.mockReturnValue(client)
+
+    await GET(makeCronRequest())
+
+    // profiles table was queried to get owner email
+    expect(client.from).toHaveBeenCalledWith('profiles')
+
+    // Email was sent to the freshly fetched address
+    expect(mockSend).toHaveBeenCalledWith(
+      expect.objectContaining({ to: UPDATED_EMAIL })
+    )
+  })
+
+  it('returns inserted count of 0 and sends no emails when no contracts exist', async () => {
+    mockCreateClient.mockReturnValue(
+      mockSupabaseClient({ contracts: [] }) as any
+    )
+
+    const res = await GET(makeCronRequest())
+    expect(res.status).toBe(200)
+
+    const body = await res.json()
+    expect(body.data.inserted).toBe(0)
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('sends no emails when shouldSendAlert returns false for all thresholds', async () => {
+    mockShouldSendAlert.mockReturnValue(false)
+    mockCreateClient.mockReturnValue(
+      mockSupabaseClient({ contracts: [mockContract] }) as any
+    )
+
+    await GET(makeCronRequest())
+    expect(mockSend).not.toHaveBeenCalled()
+  })
+
+  it('continues sending remaining emails if one email call fails', async () => {
+    // Two contracts, both at 30-day threshold
+    const contract2 = { ...mockContract, id: 'contract-2', name: 'Second Contract' }
+    const profilesQb = {
+      select: vi.fn().mockReturnThis(),
+      eq: vi.fn().mockReturnThis(),
+      single: vi.fn().mockResolvedValue({ data: { email: OWNER_EMAIL }, error: null }),
+    }
+    const notificationsQb = {
+      insert: vi.fn().mockResolvedValue({ data: null, error: null }),
+    }
+    const contractsQb: any = { select: vi.fn().mockReturnThis() }
+    contractsQb.then = (resolve: (v: unknown) => unknown) =>
+      Promise.resolve({ data: [mockContract, contract2], error: null }).then(resolve)
+
+    // First email send fails, second succeeds
+    mockSend
+      .mockRejectedValueOnce(new Error('Resend timeout'))
+      .mockResolvedValueOnce({ data: { id: 'email-2' }, error: null })
+
+    mockCreateClient.mockReturnValue({
+      from: vi.fn().mockImplementation((table: string) => {
+        if (table === 'contracts') return contractsQb
+        if (table === 'profiles') return profilesQb
+        if (table === 'notifications') return notificationsQb
+        return {}
+      }),
+    } as any)
+
+    // Should not throw — email failures must not crash the cron
+    const res = await GET(makeCronRequest())
+    expect(res.status).toBe(200)
+
+    // Both inserts succeeded
+    const body = await res.json()
+    expect(body.data.inserted).toBe(2)
+  })
+})

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -1,6 +1,9 @@
 import { NextResponse } from 'next/server'
+import { Resend } from 'resend'
 import { createClient } from '@/lib/supabase/server'
 import { shouldSendAlert, ALERT_THRESHOLDS } from '@/lib/alerts'
+
+const resend = new Resend(process.env.RESEND_API_KEY)
 
 export async function GET(req: Request) {
   // Secure with CRON_SECRET to prevent unauthorized triggering
@@ -15,9 +18,9 @@ export async function GET(req: Request) {
 
   const supabase = createClient()
 
-  // Fetch all contracts with future renewal dates + owner info
+  // Fetch all contracts with name (for email subject) + owner info
   const { data: contracts, error: contractsError } = await (supabase.from('contracts') as any)
-    .select('id, renewal_date, notice_period_days, created_by')
+    .select('id, name, renewal_date, notice_period_days, created_by')
 
   if (contractsError) {
     return NextResponse.json(
@@ -50,7 +53,29 @@ export async function GET(req: Request) {
         )
       }
 
-      if (!insertError) inserted++
+      if (!insertError) {
+        inserted++
+
+        // Send email alert — fetch owner email fresh on each run (satisfies AC-08-3)
+        try {
+          const { data: profile } = await (supabase.from('profiles') as any)
+            .select('email')
+            .eq('id', contract.created_by)
+            .single() as { data: { email: string } | null; error: unknown }
+
+          if (profile?.email) {
+            await resend.emails.send({
+              from: 'onboarding@resend.dev',
+              to: profile.email,
+              subject: `Renewal alert: ${contract.name} renews in ${threshold} days`,
+              html: `<p>Your contract <strong>${contract.name}</strong> is due for renewal in <strong>${threshold} days</strong>. Please take the necessary action to avoid auto-renewal on unfavorable terms.</p><p><a href="${process.env.NEXT_PUBLIC_APP_URL ?? 'https://contracker.vercel.app'}/contracts">View contracts</a></p>`,
+            })
+          }
+        } catch (emailError) {
+          // Email failure must not crash the cron — in-app notification was already created
+          console.error(`Failed to send renewal email for contract ${contract.id}:`, emailError)
+        }
+      }
     }
   }
 

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -3,8 +3,6 @@ import { Resend } from 'resend'
 import { createClient } from '@/lib/supabase/server'
 import { shouldSendAlert, ALERT_THRESHOLDS } from '@/lib/alerts'
 
-const resend = new Resend(process.env.RESEND_API_KEY)
-
 // Escape user-supplied content before embedding in HTML email bodies (A03 Injection)
 function escapeHtml(str: string): string {
   return str
@@ -32,6 +30,9 @@ export async function GET(req: Request) {
   }
 
   const supabase = createClient()
+  // Lazy-init Resend inside handler so module-level evaluation during `next build`
+  // doesn't throw when RESEND_API_KEY is absent in the CI build environment.
+  const resend = new Resend(process.env.RESEND_API_KEY)
 
   // Fetch contracts — bounded at 2000 rows to avoid OOM on serverless (A04)
   const { data: contracts, error: contractsError } = await (supabase.from('contracts') as any)

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -5,6 +5,21 @@ import { shouldSendAlert, ALERT_THRESHOLDS } from '@/lib/alerts'
 
 const resend = new Resend(process.env.RESEND_API_KEY)
 
+// Escape user-supplied content before embedding in HTML email bodies (A03 Injection)
+function escapeHtml(str: string): string {
+  return str
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;')
+}
+
+// Strip newlines from user content before embedding in email headers (A03 header injection)
+function sanitizeEmailHeader(str: string): string {
+  return str.replace(/[\r\n]/g, ' ').trim()
+}
+
 export async function GET(req: Request) {
   // Secure with CRON_SECRET to prevent unauthorized triggering
   const authHeader = req.headers.get('authorization')
@@ -18,13 +33,14 @@ export async function GET(req: Request) {
 
   const supabase = createClient()
 
-  // Fetch all contracts with name (for email subject) + owner info
+  // Fetch contracts — bounded at 2000 rows to avoid OOM on serverless (A04)
   const { data: contracts, error: contractsError } = await (supabase.from('contracts') as any)
     .select('id, name, renewal_date, notice_period_days, created_by')
+    .limit(2000)
 
   if (contractsError) {
     return NextResponse.json(
-      { data: null, error: { message: contractsError.message, code: '500' } },
+      { data: null, error: { message: 'Failed to fetch contracts', code: '500' } },
       { status: 500 }
     )
   }
@@ -48,7 +64,7 @@ export async function GET(req: Request) {
       // Postgres error code 23505 = unique_violation — treat as a no-op.
       if (insertError && insertError.code !== '23505') {
         return NextResponse.json(
-          { data: null, error: { message: insertError.message, code: '500' } },
+          { data: null, error: { message: 'Failed to insert notification', code: '500' } },
           { status: 500 }
         )
       }
@@ -64,11 +80,12 @@ export async function GET(req: Request) {
             .single() as { data: { email: string } | null; error: unknown }
 
           if (profile?.email) {
+            const safeName = escapeHtml(contract.name)
             await resend.emails.send({
               from: 'onboarding@resend.dev',
               to: profile.email,
-              subject: `Renewal alert: ${contract.name} renews in ${threshold} days`,
-              html: `<p>Your contract <strong>${contract.name}</strong> is due for renewal in <strong>${threshold} days</strong>. Please take the necessary action to avoid auto-renewal on unfavorable terms.</p><p><a href="${process.env.NEXT_PUBLIC_APP_URL ?? 'https://contracker.vercel.app'}/contracts">View contracts</a></p>`,
+              subject: `Renewal alert: ${sanitizeEmailHeader(contract.name)} renews in ${threshold} days`,
+              html: `<p>Your contract <strong>${safeName}</strong> is due for renewal in <strong>${threshold} days</strong>. Please take the necessary action to avoid auto-renewal on unfavorable terms.</p><p><a href="${process.env.NEXT_PUBLIC_APP_URL ?? 'https://contracker.vercel.app'}/contracts">View contracts</a></p>`,
             })
           }
         } catch (emailError) {


### PR DESCRIPTION
## C — Context

Issue #27 [M3.0] — email renewal alerts. The cron route (\`/api/cron/notifications\`) already inserts in-app notification rows and deduplicates via a DB unique index. This PR augments it to **also send emails via Resend** at the 60/30/7-day renewal thresholds.

## L — Logic

- Import \`Resend\` SDK and lazy-init inside the handler (not module-level — avoids build failure when \`RESEND_API_KEY\` is absent in the CI build environment)
- Add \`name\` to the contracts select query (needed for email subject)
- After each successful DB insert (\`!insertError\`): fetch owner's profile email fresh from \`profiles\` table, then call \`resend.emails.send()\`
- **Deduplication is natural**: email fires only when insert succeeds; unique index \`(contract_id, threshold_days)\` blocks duplicate inserts → email never fires twice (AC-08-2)
- Email failure is non-fatal: wrapped in \`try/catch\`, logged, cron continues processing remaining contracts

Security hardening (from \`security-reviewer\` agent findings):
- \`escapeHtml()\` — escapes \`<>&"'\` in contract name before HTML email body (A03)
- \`sanitizeEmailHeader()\` — strips \`\r\n\` from contract name in email subject (A03 header injection)
- \`.limit(2000)\` on contracts query — bounds serverless memory usage (A04)
- Generic error messages in 500 responses (no internal DB details leaked)

## E — Evidence

- **TDD red commit:** \`test: add failing cron email tests (AC-08-1, AC-08-2, AC-08-3)\` — 2 tests failed, 6 passed
- **TDD green commit:** \`feat: augment cron route to send Resend email on successful insert\` — all 8 pass
- **Security fix commit:** \`fix: harden cron route against email injection and unbounded fetch\`
- **Build fix commit:** \`fix: lazy-init Resend inside handler to unblock next build in CI\`
- 201/201 tests passing after this branch

## A — Alternatives

Considered Supabase Edge Function (per original PRD design) but a Next.js API route is simpler to test, deploy, and mock without Deno runtime overhead.

## R — Risks

- \`onboarding@resend.dev\` as \`from\` address works for Resend free tier (no domain verification needed). A verified custom domain (\`alerts@contracker.dev\`) should replace this before a paid production launch.
- Cron route is bounded at 2000 contracts; a pagination loop can be added if scale requires it.

---

**Test plan:**
- [x] \`npm test\` — 201/201 passing
- [x] \`npm run type-check\` — clean
- [x] \`npm run lint\` — clean
- [x] \`security-reviewer\` agent run — 3 findings, all fixed in this PR
- [x] Manual: triggered \`GET /api/cron/notifications\` with \`Authorization: Bearer <CRON_SECRET>\` header — response \`{"data":{"inserted":0},"error":null}\` ✅
- [x] CI passes all 8 stages — lint, type-check, tests, build, E2E, security scan, AI review, Lighthouse ✅

🤖 Generated with [Claude Code](https://claude.com/claude-code) — ~85% AI-generated (route augmentation + tests); security hardening based on security-reviewer agent output

Closes #27