### PR TITLE
chore: schedule renewal alert cron daily at 09:00 UTC (#69)

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -2,5 +2,11 @@
   "framework": "nextjs",
   "buildCommand": "npm run build",
   "devCommand": "npm run dev",
-  "installCommand": "npm install"
+  "installCommand": "npm install",
+  "crons": [
+    {
+      "path": "/api/cron/notifications",
+      "schedule": "0 9 * * *"
+    }
+  ]
 }


### PR DESCRIPTION
## Summary

- Added `crons` entry to `vercel.json` to schedule `GET /api/cron/notifications` daily at **09:00 UTC**
- Vercel automatically supplies `Authorization: Bearer <CRON_SECRET>` on each invocation, matching the auth check already in the route handler
- The cron route was fully implemented in a prior PR — this is purely the missing scheduler config

## Pre-merge checklist

Before merging, confirm these environment variables are set in the **Vercel production dashboard**:

- [ ] `CRON_SECRET` — matches the value checked in `/api/cron/notifications/route.ts`
- [ ] `RESEND_API_KEY` — Resend API key for email delivery
- [ ] `NEXT_PUBLIC_APP_URL` — `https://contracker.vercel.app` (used in email body links)

## Test plan

- [ ] After deploy, manually trigger the endpoint: `GET /api/cron/notifications` with `Authorization: Bearer <CRON_SECRET>`
- [ ] Confirm a `notifications` row is inserted for any contract within the 60/30/7-day threshold
- [ ] Confirm a Resend email is delivered to the contract owner's inbox
- [ ] Trigger again — confirm no duplicate notification row is created (unique index enforces idempotency)
- [ ] Verify the Vercel dashboard shows the cron job listed under **Cron Jobs** tab after deploy

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)