### PR TITLE
fix: normalize today to midnight UTC in cron alert check (#69)

### DIFF
--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -46,7 +46,9 @@ export async function GET(req: Request) {
     )
   }
 
-  const today = new Date()
+  // Normalize to midnight UTC so diffInDays() returns whole-day integers
+  // matching the DATE values stored in Postgres (also midnight UTC)
+  const today = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z')
   let inserted = 0
 
   for (const contract of contracts as any[]) {


### PR DESCRIPTION
## Summary

Two bugs found and fixed while verifying the cron end-to-end:

**Bug 1 — Wrong day count (midnight normalization)**
`diffInDays()` uses `Math.floor` on milliseconds. `today = new Date()` includes wall-clock time (e.g. `17:30 UTC`), but Postgres `DATE` values come back as midnight UTC. A contract exactly 7 days away would floor to `6`, so `shouldSendAlert(=== 7)` always returned `false`. Fixed by normalizing `today` to midnight UTC.

**Bug 2 — RLS blocks contract reads (service role)**
The cron runs without a user session. The anon key is subject to RLS, and the contracts table requires `authenticated` role to read — so the cron was silently fetching 0 rows. Fixed by switching to the service role key, which bypasses RLS server-side.

## Test plan

- [x] `inserted: 0` before fix — midnight normalization bug + RLS blocked contract reads
- [ ] After merge + deploy, trigger cron: `GET /api/cron/notifications` with `Authorization: Bearer <CRON_SECRET>`
- [ ] Confirm `{"data":{"inserted":N}}` — notifications created for qualifying contracts
- [ ] Trigger again — confirm `{"data":{"inserted":0}}` (idempotency via unique index)

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)