### PR TITLE
fix: use service role key in cron to bypass RLS (#69)

### DIFF
--- a/__tests__/api/cron.test.ts
+++ b/__tests__/api/cron.test.ts
@@ -25,7 +25,7 @@ vi.mock('resend', () => ({
   })),
 }))
 
-vi.mock('@/lib/supabase/server', () => ({
+vi.mock('@supabase/supabase-js', () => ({
   createClient: vi.fn(),
 }))
 
@@ -36,11 +36,11 @@ vi.mock('@/lib/alerts', () => ({
   ALERT_THRESHOLDS: [60, 30, 7] as const,
 }))
 
-import { createClient } from '@/lib/supabase/server'
+import { createClient as createServiceClient } from '@supabase/supabase-js'
 import { shouldSendAlert } from '@/lib/alerts'
 import { GET } from '@/app/api/cron/notifications/route'
 
-const mockCreateClient = vi.mocked(createClient)
+const mockCreateClient = vi.mocked(createServiceClient)
 const mockShouldSendAlert = vi.mocked(shouldSendAlert)
 
 // ─── Constants ────────────────────────────────────────────────────────────────

--- a/app/api/cron/notifications/route.ts
+++ b/app/api/cron/notifications/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from 'next/server'
 import { Resend } from 'resend'
-import { createClient } from '@/lib/supabase/server'
+import { createClient as createServiceClient } from '@supabase/supabase-js'
 import { shouldSendAlert, ALERT_THRESHOLDS } from '@/lib/alerts'
 
 // Escape user-supplied content before embedding in HTML email bodies (A03 Injection)
@@ -29,7 +29,11 @@ export async function GET(req: Request) {
     )
   }
 
-  const supabase = createClient()
+  // Use service role key to bypass RLS — cron has no user session
+  const supabase = createServiceClient(
+    process.env.NEXT_PUBLIC_SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE_KEY!
+  )
   // Lazy-init Resend inside handler so module-level evaluation during `next build`
   // doesn't throw when RESEND_API_KEY is absent in the CI build environment.
   const resend = new Resend(process.env.RESEND_API_KEY)


### PR DESCRIPTION
## Summary

Two bugs found and fixed while verifying the cron end-to-end:

**Bug 1 — RLS blocks contract reads (service role)**
The cron runs without a user session. The anon key is subject to RLS, and the contracts table has an RLS policy requiring \`authenticated\` role to read — so the cron was silently fetching 0 rows. Fixed by switching to the service role key, which bypasses RLS server-side.

**Bug 2 — Test mocks updated**
The cron test file mocked \`@/lib/supabase/server\` — updated to mock \`@supabase/supabase-js\` to match the new import.

## Test plan

- [x] Before fix: \`{"data":{"inserted":0}}\` — cron fetched 0 contracts due to RLS
- [x] After deploy, triggered cron: \`{"data":{"inserted":1}}\` — notification inserted for E2E Risk Badge Red Contract at 7-day threshold
- [x] Triggered again: \`{"data":{"inserted":0}}\` — idempotency confirmed via unique index
- [x] DB confirmed: notification row exists for E2E Risk Badge Red Contract, threshold_days=7, is_read=false

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)