### PR TITLE
fix: notifications read-archive — return all and count unread client-side

### DIFF
--- a/app/api/notifications/route.ts
+++ b/app/api/notifications/route.ts
@@ -16,7 +16,6 @@ export async function GET(_req: Request) {
     .from('notifications')
     .select('*, contracts(id, name, renewal_date, suppliers(name))')
     .eq('user_id', user.id)
-    .eq('is_read', false)
     .order('created_at', { ascending: false })
 
   if (error) {

--- a/components/shared/NotificationBell.tsx
+++ b/components/shared/NotificationBell.tsx
@@ -16,7 +16,11 @@ export function NotificationBell() {
         const res = await fetch('/api/notifications')
         if (!res.ok) return
         const json = await res.json()
-        setUnreadCount(Array.isArray(json.data) ? json.data.length : 0)
+        setUnreadCount(
+          Array.isArray(json.data)
+            ? json.data.filter((n: { is_read: boolean }) => !n.is_read).length
+            : 0
+        )
       } catch {
         // silently ignore — bell just shows no badge
       }


### PR DESCRIPTION
## Summary

- `GET /api/notifications` was filtering `is_read = false` server-side, so notifications marked as read vanished instead of appearing in the 'read' tab
- Removed the `.eq('is_read', false)` filter so the endpoint returns all notifications for the user
- `NotificationBell` now counts only `!n.is_read` entries for the badge (was counting total length)

## Test plan

- [ ] All 245 unit tests pass (`npm test -- --run`)
- [ ] Mark a notification as read → verify it moves to the 'read' tab instead of disappearing
- [ ] Verify the bell badge decrements correctly after marking as read
- [ ] Verify the 'unread' tab still shows only unread notifications

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)