### PR TITLE
fix: dashboard alerts panel shows unread-only

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -205,10 +205,9 @@ function AlertsFeedPanel() {
     Promise.all(unreadIds.map((id) => fetch(`/api/notifications/${id}`, { method: 'PUT' })))
   }
 
-  const sorted = [...notifications].sort((a, b) => {
-    if (a.isRead !== b.isRead) return a.isRead ? 1 : -1
-    return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime()
-  })
+  const sorted = [...notifications]
+    .filter((n) => !n.isRead)
+    .sort((a, b) => new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime())
 
   const itemVariants = {
     hidden: { opacity: 0, x: shouldReduceMotion ? 0 : 16 },


### PR DESCRIPTION
## Summary

- PR #79 removed the `is_read=false` server-side filter from `GET /api/notifications` so the notifications page archive tab works correctly
- Side effect: the dashboard Alerts panel started rendering all notifications (read + unread) since it used the same endpoint
- Fix: filter `sorted` to `!isRead` before rendering so the dashboard panel only shows active unread alerts

## Test plan

- [x] All 245 unit tests pass
- [x] Dashboard Alerts panel shows only unread notifications
- [x] Marking an alert as read in the dashboard removes it from the panel immediately
- [x] Navigating to /notifications still shows all notifications (read tab works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)