### PR TITLE
fix: add certification UI to supplier detail page

### DIFF
--- a/app/(app)/suppliers/[id]/certifications/new/page.tsx
+++ b/app/(app)/suppliers/[id]/certifications/new/page.tsx
@@ -1,0 +1,173 @@
+'use client'
+
+import { useState } from 'react'
+import { useParams, useRouter } from 'next/navigation'
+import Link from 'next/link'
+import { ArrowLeft, Loader2 } from 'lucide-react'
+import { motion } from 'framer-motion'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useToast } from '@/components/ui/use-toast'
+
+const CERT_TYPES = [
+  { value: 'ISO', label: 'ISO' },
+  { value: 'NDA', label: 'NDA' },
+  { value: 'insurance', label: 'Insurance' },
+  { value: 'other', label: 'Other' },
+]
+
+export default function NewCertificationPage() {
+  const params = useParams<{ id: string }>()
+  const supplierId = params.id
+  const router = useRouter()
+  const { toast } = useToast()
+
+  const [form, setForm] = useState({
+    cert_type: 'ISO',
+    issued_date: '',
+    expiry_date: '',
+  })
+  const [error, setError] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+
+  function set(field: string, value: string) {
+    setForm(prev => ({ ...prev, [field]: value }))
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault()
+    setError(null)
+
+    if (!form.expiry_date) {
+      setError('Expiry date is required.')
+      return
+    }
+
+    setLoading(true)
+    try {
+      const res = await fetch('/api/certifications', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          supplier_id: supplierId,
+          cert_type: form.cert_type,
+          issued_date: form.issued_date || undefined,
+          expiry_date: form.expiry_date,
+        }),
+      })
+
+      const body = await res.json()
+      if (!res.ok) {
+        setError(body.error?.message ?? 'Something went wrong.')
+        return
+      }
+
+      toast({ title: 'Certification added' })
+      router.push(`/suppliers/${supplierId}`)
+    } catch {
+      setError('Network error — please try again.')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="mx-auto max-w-lg space-y-6">
+      <Button asChild variant="ghost" size="sm" className="text-muted-foreground">
+        <Link href={`/suppliers/${supplierId}`}>
+          <ArrowLeft className="mr-1.5 h-4 w-4" />
+          Back to Supplier
+        </Link>
+      </Button>
+
+      <div>
+        <h2 className="text-2xl font-display font-bold tracking-tight text-foreground text-glow">
+          Add Certification
+        </h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Attach a compliance certificate to this supplier.
+        </p>
+      </div>
+
+      <motion.form
+        onSubmit={handleSubmit}
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: 0.25 }}
+        className="space-y-5 rounded-xl border border-white/[0.08] bg-white/[0.03] p-6"
+      >
+        {/* Cert type */}
+        <div className="space-y-1.5">
+          <Label htmlFor="cert_type">Certification Type</Label>
+          <Select value={form.cert_type} onValueChange={v => set('cert_type', v)}>
+            <SelectTrigger id="cert_type">
+              <SelectValue placeholder="Select type" />
+            </SelectTrigger>
+            <SelectContent>
+              {CERT_TYPES.map(t => (
+                <SelectItem key={t.value} value={t.value}>{t.label}</SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        {/* Issued date (optional) */}
+        <div className="space-y-1.5">
+          <Label htmlFor="issued_date">
+            Issue Date <span className="text-muted-foreground">(optional)</span>
+          </Label>
+          <Input
+            id="issued_date"
+            type="date"
+            value={form.issued_date}
+            onChange={e => set('issued_date', e.target.value)}
+          />
+        </div>
+
+        {/* Expiry date (required) */}
+        <div className="space-y-1.5">
+          <Label htmlFor="expiry_date">
+            Expiry Date <span className="text-red-400">*</span>
+          </Label>
+          <Input
+            id="expiry_date"
+            type="date"
+            required
+            value={form.expiry_date}
+            onChange={e => set('expiry_date', e.target.value)}
+          />
+        </div>
+
+        {error && (
+          <p className="rounded-lg border border-red-500/20 bg-red-500/10 px-3 py-2 text-sm text-red-400">
+            {error}
+          </p>
+        )}
+
+        <div className="flex items-center gap-3 pt-1">
+          <Button type="submit" disabled={loading} className="flex-1">
+            {loading ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving…
+              </>
+            ) : (
+              'Add Certification'
+            )}
+          </Button>
+          <Button asChild variant="outline">
+            <Link href={`/suppliers/${supplierId}`}>Cancel</Link>
+          </Button>
+        </div>
+      </motion.form>
+    </div>
+  )
+}

--- a/app/(app)/suppliers/[id]/certifications/new/page.tsx
+++ b/app/(app)/suppliers/[id]/certifications/new/page.tsx
@@ -72,6 +72,7 @@ export default function NewCertificationPage() {
 
       toast({ title: 'Certification added' })
       router.push(`/suppliers/${supplierId}`)
+      router.refresh()
     } catch {
       setError('Network error — please try again.')
     } finally {

--- a/app/(app)/suppliers/[id]/page.tsx
+++ b/app/(app)/suppliers/[id]/page.tsx
@@ -1,11 +1,11 @@
 import Link from 'next/link'
 import { notFound } from 'next/navigation'
-import { ArrowLeft, Edit2, FileText } from 'lucide-react'
+import { ArrowLeft, Edit2, FileText, ShieldCheck, ShieldAlert, ShieldX, Plus, Award } from 'lucide-react'
 import { Button } from '@/components/ui/button'
 import { Badge } from '@/components/ui/badge'
 import { createClient } from '@/lib/supabase/server'
 import { formatDate, formatCurrency } from '@/lib/utils'
-import { getContractStatus, getRiskColour } from '@/lib/risk'
+import { getContractStatus, getRiskColour, getCertificationStatus } from '@/lib/risk'
 import { RiskBadge } from '@/components/ui/RiskBadge'
 
 export default async function SupplierDetailPage({
@@ -17,7 +17,7 @@ export default async function SupplierDetailPage({
 
   // Cast needed: Supabase strict generics don't resolve relational select types correctly.
   const { data: supplier, error } = await (supabase.from('suppliers') as any)
-    .select('*, contracts(*)')
+    .select('*, contracts(*), certifications(*)')
     .eq('id', params.id)
     .single() as {
       data: {
@@ -29,6 +29,7 @@ export default async function SupplierDetailPage({
         contact_email: string | null
         contact_phone: string | null
         contracts: any[]
+        certifications: any[]
       } | null
       error: unknown
     }
@@ -36,6 +37,10 @@ export default async function SupplierDetailPage({
   if (error || !supplier) notFound()
 
   const contracts = supplier.contracts ?? []
+  const certifications = (supplier.certifications ?? []).map((c: any) => ({
+    ...c,
+    certStatus: getCertificationStatus(new Date(c.expiry_date)),
+  }))
 
   // Compute derived stats for the health panel
   const totalValue = contracts.reduce((s: number, c: any) => s + (c.value ?? 0), 0)
@@ -203,6 +208,71 @@ export default async function SupplierDetailPage({
                       </td>
                       <td className="px-4 py-3">
                         <RiskBadge status={status} risk={risk} />
+                      </td>
+                    </tr>
+                  )
+                })}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+
+      {/* Certifications */}
+      <div className="space-y-3">
+        <div className="flex items-center justify-between">
+          <h3 className="text-sm font-semibold text-foreground">
+            Certifications ({certifications.length})
+          </h3>
+          <Button asChild variant="outline" size="sm">
+            <Link href={`/suppliers/${supplier.id}/certifications/new`}>
+              <Plus className="mr-1.5 h-3.5 w-3.5" />
+              Add Certification
+            </Link>
+          </Button>
+        </div>
+
+        {certifications.length === 0 ? (
+          <div className="flex flex-col items-center justify-center rounded-xl border border-white/[0.08] bg-white/[0.03] py-10 text-center">
+            <Award className="mb-3 h-8 w-8 text-muted-foreground/40" />
+            <p className="text-sm text-muted-foreground">No certifications on file</p>
+            <Button asChild variant="ghost" size="sm" className="mt-3 text-indigo-400">
+              <Link href={`/suppliers/${supplier.id}/certifications/new`}>Add one now</Link>
+            </Button>
+          </div>
+        ) : (
+          <div className="overflow-hidden rounded-xl border border-white/[0.08] bg-white/[0.03]">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-white/[0.06]">
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Type</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Issued</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Expires</th>
+                  <th className="px-4 py-3 text-left font-medium text-muted-foreground">Status</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-white/[0.04]">
+                {certifications.map((c: any) => {
+                  const certStatusConfig = {
+                    valid:    { label: 'Valid',    cls: 'bg-emerald-500/15 text-emerald-400 border-emerald-500/20', Icon: ShieldCheck },
+                    expiring: { label: 'Expiring', cls: 'bg-amber-500/15 text-amber-400 border-amber-500/20',   Icon: ShieldAlert },
+                    expired:  { label: 'Expired',  cls: 'bg-red-500/15 text-red-400 border-red-500/20',         Icon: ShieldX },
+                  }[c.certStatus as 'valid' | 'expiring' | 'expired']
+
+                  return (
+                    <tr key={c.id} className="transition-colors hover:bg-white/[0.03]">
+                      <td className="px-4 py-3 font-medium text-foreground capitalize">
+                        {c.cert_type === 'insurance' ? 'Insurance' : c.cert_type}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">
+                        {c.issued_date ? formatDate(c.issued_date) : '—'}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground">{formatDate(c.expiry_date)}</td>
+                      <td className="px-4 py-3">
+                        <span className={`inline-flex items-center gap-1 rounded-full border px-2 py-0.5 text-xs font-medium ${certStatusConfig.cls}`}>
+                          <certStatusConfig.Icon className="h-3 w-3" />
+                          {certStatusConfig.label}
+                        </span>
                       </td>
                     </tr>
                   )


### PR DESCRIPTION
## Summary

- Extends the supplier detail page to fetch and display certifications with computed status badges (Valid / Expiring / Expired), matching the compliance page's traffic-light style
- Adds a new `/suppliers/[id]/certifications/new` form page that POSTs to the existing `/api/certifications` endpoint and redirects back to the supplier profile
- Fixes stale data on redirect by calling `router.refresh()` to bust the Next.js RSC cache after a successful submission

## Root cause

M3.2 (Sprint 3) implemented the certifications API and compliance page but never wired up a UI entry point on the supplier detail page — certifications could only be added via direct API calls.

## Test plan

- [x] Navigate to any supplier detail page — Certifications section visible below Contracts
- [x] Empty state shows "No certifications on file" with an "Add one now" link
- [x] Click "Add Certification" → form renders with Type, Issue Date (optional), Expiry Date (required)
- [x] Submit valid data → redirects to supplier detail → new cert appears immediately (no manual reload needed)
- [x] Submit with empty expiry date → stays on form with validation error
- [x] Cancel → returns to supplier detail page
- [x] `npm test` — 252/252 passing, no regressions
- [x] `npm run type-check` — no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)