### PR TITLE
docs: add demo video link, deliverables callout, and finalize requirements doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Contract & Supplier Management Platform built with Next.js 14, Supabase, and dep
 [![Deploy](https://github.com/CS-7180/Contracker/actions/workflows/deploy.yml/badge.svg)](https://github.com/CS-7180/Contracker/actions/workflows/deploy.yml)
 [![Production](https://img.shields.io/badge/production-live-brightgreen)](https://contracker-zeta.vercel.app/)
 
-> **Live app:** [https://contracker-zeta.vercel.app](https://contracker-zeta.vercel.app)
-> **Blog post:** [Building Contracker with TDD + Claude Code](https://medium.com/@vineela.vgoli/contracker-40789a7c71ff)
-> **Demo video:** [https://youtu.be/bnh0SqMpClo](https://youtu.be/bnh0SqMpClo)
+> **Live app:** [https://contracker-zeta.vercel.app](https://contracker-zeta.vercel.app)  
+> **Blog post:** [Building Contracker with TDD + Claude Code](https://medium.com/@vineela.vgoli/contracker-40789a7c71ff)  
+> **Demo video:** [https://youtu.be/bnh0SqMpClo](https://youtu.be/bnh0SqMpClo)  
 
 > [!NOTE]
 > **CS7180 Project Deliverables** — The full requirements fulfillment checklist (CLAUDE.md, skills, hooks, MCP servers, agents, TDD evidence, CI/CD pipeline, and bonus work) is documented in [`docs/Project_Requirements_Fulfillment.md`](docs/Project_Requirements_Fulfillment.md).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@ Contract & Supplier Management Platform built with Next.js 14, Supabase, and dep
 
 > **Live app:** [https://contracker-zeta.vercel.app](https://contracker-zeta.vercel.app)
 > **Blog post:** [Building Contracker with TDD + Claude Code](https://medium.com/@vineela.vgoli/contracker-40789a7c71ff)
+> **Demo video:** [https://youtu.be/bnh0SqMpClo](https://youtu.be/bnh0SqMpClo)
+
+> [!NOTE]
+> **CS7180 Project Deliverables** — The full requirements fulfillment checklist (CLAUDE.md, skills, hooks, MCP servers, agents, TDD evidence, CI/CD pipeline, and bonus work) is documented in [`docs/Project_Requirements_Fulfillment.md`](docs/Project_Requirements_Fulfillment.md).
 
 ---
 
@@ -191,4 +195,6 @@ Role is stored on `profiles.role` and enforced server-side via `lib/auth.ts:requ
 - [Sprint Plan](docs/sprint-plan.md)
 - [Sprint Retrospectives](docs/sprint-retrospectives.md)
 - [Security](docs/security.md)
+- [Project Requirements Fulfillment](docs/Project_Requirements_Fulfillment.md)
 - [Blog Post](https://medium.com/@vineela.vgoli/contracker-40789a7c71ff)
+- [Demo Video](https://youtu.be/bnh0SqMpClo)

--- a/docs/Project_Requirements_Fulfillment.md
+++ b/docs/Project_Requirements_Fulfillment.md
@@ -211,11 +211,7 @@ Peer evaluation evidence from Vineela and Raj's teams conversation is shown in `
 Published on Medium: https://medium.com/@vineela.vgoli/contracker-40789a7c71ff
 
 ### Video demonstration
-`[PLACEHOLDER — Insert video URL here: _________________]`
-*(5–10 min screencast covering: problem statement, live walkthrough of all 8 pages, Claude Code workflow showing CLAUDE.md + a TDD commit sequence + a C.L.E.A.R. PR review, CI/CD all-green view, and closing.)*
-
-### Showcase form submission
-`[PLACEHOLDER — Submit the Google Form before Apr 22 by 2:59am: project name (Contracker), production URL, thumbnail, video URL, blog URL. Form: https://docs.google.com/forms/d/e/1FAIpQLScT67tnwjhIETSRwADt57TS_THJSeSGf-xrjTV2nm-XvfFELg/viewform?usp=dialog]`
+`[[Demo](https://youtu.be/bnh0SqMpClo)]`
 
 ---
 


### PR DESCRIPTION
## Summary

- Replaces video/form placeholders in `docs/Project_Requirements_Fulfillment.md` with the actual demo link (`https://youtu.be/bnh0SqMpClo`)
- Adds the demo video link to `README.md` alongside the live app and blog post links
- Adds a `[!NOTE]` callout near the top of `README.md` pointing graders to `docs/Project_Requirements_Fulfillment.md` for the full deliverables checklist
- Adds `Project Requirements Fulfillment` and `Demo Video` entries to the README Docs section

## Test plan

- [ ] README renders correctly on GitHub (note callout visible, all links resolve)
- [ ] Demo video link opens `https://youtu.be/bnh0SqMpClo`
- [ ] `docs/Project_Requirements_Fulfillment.md` link in callout navigates correctly

## AI Disclosure

| Field | Value |
|-------|-------|
| Tool | Claude Code (claude-sonnet-4-6) |
| % AI-generated | 100% |
| Human review | Verified diff — placeholder removal and link additions only |

🤖 Generated with [Claude Code](https://claude.com/claude-code)